### PR TITLE
SC-131: Migrate to ESP protection system

### DIFF
--- a/.changeset/heavy-crabs-hunt.md
+++ b/.changeset/heavy-crabs-hunt.md
@@ -1,0 +1,5 @@
+---
+'solar-control-be': minor
+---
+
+SC-131: Migrate to ESP protection system

--- a/src/api/modules/esp/types/esp.schema.d.ts
+++ b/src/api/modules/esp/types/esp.schema.d.ts
@@ -234,7 +234,11 @@ export interface components {
        * @description Data collection date in UTC
        */
       createdAt: string;
+      /** @description Status of the power relay */
+      power: boolean;
       sensors: components['schemas']['Sensor'][];
+      /** @description Indicator to point whether protection has been triggered */
+      pTriggered: boolean;
     };
     Sensor: {
       /** @description The name of the sensor */
@@ -244,6 +248,11 @@ export interface components {
        * @description AC/DC voltage in Volts
        */
       voltage?: number;
+      /**
+       * Format: float
+       * @description AC/DC average voltage in Volts
+       */
+      avgVoltage?: number;
       /**
        * Format: float
        * @description AC/DC current in Amps

--- a/src/api/modules/esp/ws/sensors/fake-sensors.service.ts
+++ b/src/api/modules/esp/ws/sensors/fake-sensors.service.ts
@@ -31,6 +31,8 @@ export class EspFakeSensorsWsService {
     return {
       createdAt: new Date().toJSON(),
       sensors,
+      power: true,
+      pTriggered: false,
     };
   }
 

--- a/src/api/modules/esp/ws/sensors/fake-sensors.service.ts
+++ b/src/api/modules/esp/ws/sensors/fake-sensors.service.ts
@@ -30,8 +30,8 @@ export class EspFakeSensorsWsService {
 
     return {
       createdAt: new Date().toJSON(),
-      sensors,
       power: true,
+      sensors,
       pTriggered: false,
     };
   }

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -23,6 +23,7 @@ export interface AppConfigType {
   };
   feature: {
     clearSensors: boolean;
+    useEspAvgVoltage: boolean;
     sensorCalcPeriod: number;
   };
   logLevel: PinoLogLevel;
@@ -55,6 +56,10 @@ class AppEnvVariables {
   @IsNotEmpty()
   SENSORS_CLEAR_ON_START!: boolean;
 
+  @IsBoolean()
+  @IsNotEmpty()
+  SENSORS_USE_ESP_AVG_VOLTAGE!: boolean;
+
   @IsNumber()
   @IsNotEmpty()
   SENSORS_CALC_PERIOD!: number;
@@ -84,6 +89,7 @@ export const AppConfig = registerAs<AppConfigType>(
       },
       feature: {
         clearSensors: config.SENSORS_CLEAR_ON_START,
+        useEspAvgVoltage: config.SENSORS_USE_ESP_AVG_VOLTAGE,
         sensorCalcPeriod: config.SENSORS_CALC_PERIOD,
       },
       logLevel: config.LOG_LEVEL,

--- a/src/modules/protection-rules/dto/protection-rule-result.dto.ts
+++ b/src/modules/protection-rules/dto/protection-rule-result.dto.ts
@@ -6,5 +6,5 @@ export class ProtectionRuleResultDto
   acOutputFrequency = false;
   acOutputVoltage = false;
   acOutputAvgVoltage = false;
-  dcBatteryVoltage = false;
+  dcBatteryAvgVoltage = false;
 }

--- a/src/modules/protection-rules/enums/protection-rules.enum.ts
+++ b/src/modules/protection-rules/enums/protection-rules.enum.ts
@@ -2,7 +2,7 @@ export enum ProtectionRuleId {
   AC_OUTPUT_FREQUENCY = 'acOutputFrequency',
   AC_OUTPUT_VOLTAGE = 'acOutputVoltage',
   AC_OUTPUT_AVG_VOLTAGE = 'acOutputAvgVoltage',
-  DC_BATTERY_VOLTAGE = 'dcBatteryVoltage',
+  DC_BATTERY_AVG_VOLTAGE = 'dcBatteryAvgVoltage',
 }
 
 export const enum ProtectionRulesCacheKey {

--- a/src/modules/protection-rules/protection-rules.constants.ts
+++ b/src/modules/protection-rules/protection-rules.constants.ts
@@ -1,4 +1,4 @@
-import { ProtectionRulesCacheKey, ProtectionRuleId } from './enums';
+import { ProtectionRulesCacheKey } from './enums';
 import { DateMilliseconds } from '@common/enums/date.enum';
 import { TypeORMCacheConfig } from '@common/types';
 
@@ -15,11 +15,5 @@ export const PROTECTION_RULES_CACHE_CONFIG: TypeORMCacheConfig<ProtectionRulesCa
       milliseconds: DateMilliseconds.DAY,
     },
   };
-
-export const ALLOWED_RULES_TO_SAVE: ProtectionRuleId[] = [
-  ProtectionRuleId.AC_OUTPUT_FREQUENCY,
-  ProtectionRuleId.AC_OUTPUT_VOLTAGE,
-  ProtectionRuleId.DC_BATTERY_VOLTAGE,
-];
 
 export const PROTECTION_RESULT_KEY = 'protectionResult';

--- a/src/modules/protection-rules/protection-rules.executor.ts
+++ b/src/modules/protection-rules/protection-rules.executor.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { SensorId } from '../sensors/enums';
-import { SensorItem } from '../sensors/entities';
+import { Sensor } from '../sensors/entities';
 import { ProtectionRule } from './entities';
 import { ProtectionStrategy } from './strategies';
 import { PROTECTION_STRATEGY_CONFIG } from './protection-rules.constants';
@@ -14,7 +14,7 @@ export class ProtectionRulesExecutor {
     private readonly strategyConfig: Record<SensorId, ProtectionStrategy>,
   ) {}
 
-  execute(sensors: SensorItem[], rules: ProtectionRule[]): ProtectionResultDto {
+  execute(sensor: Sensor, rules: ProtectionRule[]): ProtectionResultDto {
     const mappedRules = rules.reduce(
       (acc, rule) => {
         acc[rule.id] = rule;
@@ -25,23 +25,23 @@ export class ProtectionRulesExecutor {
     );
     const result = new ProtectionResultDto();
 
-    for (const sensor of sensors) {
-      if (!sensor.name) {
+    for (const sensorItem of sensor.sensors) {
+      if (!sensorItem.name) {
         continue;
       }
 
-      const selected = this.strategyConfig[sensor.name];
+      const selected = this.strategyConfig[sensorItem.name];
 
       if (!selected) {
         continue;
       }
 
-      const strategyResult = selected.run(sensor, mappedRules);
+      const strategyResult = selected.run(sensorItem, mappedRules);
 
       Object.assign(result.rules, strategyResult);
     }
 
-    result.triggered = Object.values(result.rules).some(Boolean);
+    result.triggered = sensor.pTriggered;
 
     return result;
   }

--- a/src/modules/protection-rules/protection-rules.module.ts
+++ b/src/modules/protection-rules/protection-rules.module.ts
@@ -15,7 +15,6 @@ import { LogsModule } from '../logs/logs.module';
 import { SensorId } from '../sensors/enums';
 import { AsicsModule } from '../asics/asics.module';
 import { ProtectionRulesExecutor } from './protection-rules.executor';
-import { RelaysModule } from '../relays/relays.module';
 
 const STRATEGIES = [AcOutputProtectionStrategy, DcBatteryProtectionStrategy];
 
@@ -25,7 +24,6 @@ const STRATEGIES = [AcOutputProtectionStrategy, DcBatteryProtectionStrategy];
     EspApiModule,
     LogsModule,
     AsicsModule,
-    RelaysModule,
   ],
   controllers: [ProtectionRulesController],
   providers: [

--- a/src/modules/protection-rules/protection-rules.service.ts
+++ b/src/modules/protection-rules/protection-rules.service.ts
@@ -12,13 +12,9 @@ import { LogsService } from '../logs/logs.service';
 import { LogType } from '../logs/enums';
 import { Observable, Subject, map } from 'rxjs';
 import { ProtectionRulesExecutor } from './protection-rules.executor';
-import {
-  ALLOWED_RULES_TO_SAVE,
-  PROTECTION_RESULT_KEY,
-} from './protection-rules.constants';
+import { PROTECTION_RESULT_KEY } from './protection-rules.constants';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
-import { RelaysService } from '../relays/relays.service';
 
 @Injectable()
 export class ProtectionRulesService {
@@ -35,7 +31,6 @@ export class ProtectionRulesService {
     private readonly logsService: LogsService,
     @Inject(CACHE_MANAGER)
     private readonly cache: Cache,
-    private readonly relaysService: RelaysService,
   ) {}
 
   @OnEvent(SENSORS_DATA_EVENT)
@@ -51,10 +46,7 @@ export class ProtectionRulesService {
         return;
       }
 
-      const result = this.protectionStrategyExecutor.execute(
-        sensor.sensors,
-        rules,
-      );
+      const result = this.protectionStrategyExecutor.execute(sensor, rules);
 
       await this.handleProtectionResult(result);
     } catch (err) {
@@ -74,8 +66,6 @@ export class ProtectionRulesService {
 
     if (!result.triggered && this.isRequestSent) {
       this.isRequestSent = false;
-
-      await this.relaysService.switchPower(true, LogType.PROTECTION);
     }
 
     if (result.triggered && !this.isRequestSent) {
@@ -86,7 +76,6 @@ export class ProtectionRulesService {
       await Promise.allSettled(
         this.asicsService.stopAsics(asics, LogType.PROTECTION),
       );
-      await this.relaysService.switchPower(false, LogType.PROTECTION);
     }
   }
 
@@ -102,9 +91,7 @@ export class ProtectionRulesService {
     id: ProtectionRuleId,
     ruleDto: ProtectionRuleDto,
   ): Promise<ProtectionRule> {
-    if (ALLOWED_RULES_TO_SAVE.includes(id)) {
-      await this.espProtectionRulesApiService.saveProtectionRule(id, ruleDto);
-    }
+    await this.espProtectionRulesApiService.saveProtectionRule(id, ruleDto);
 
     return this.protectionRulesRepository.saveRule(id, ruleDto);
   }

--- a/src/modules/protection-rules/strategies/ac-output-protection.strategy.ts
+++ b/src/modules/protection-rules/strategies/ac-output-protection.strategy.ts
@@ -37,7 +37,7 @@ export class AcOutputProtectionStrategy extends ProtectionStrategy {
       result.acOutputVoltage = true;
     }
 
-    if (this.checkRule(rules.acOutputAvgVoltage, sensor.avgVoltage)) {
+    if (sensor.protection?.acOutputAvgVoltage && rules.acOutputAvgVoltage) {
       this.logRule(rules.acOutputAvgVoltage, sensor.avgVoltage);
 
       result.acOutputAvgVoltage = true;

--- a/src/modules/protection-rules/strategies/dc-battery-protection.strategy.ts
+++ b/src/modules/protection-rules/strategies/dc-battery-protection.strategy.ts
@@ -20,13 +20,13 @@ export class DcBatteryProtectionStrategy extends ProtectionStrategy {
     rules: Record<ProtectionRuleId, ProtectionRule>,
   ): ProtectionRuleResult {
     const result: ProtectionRuleResult = {
-      dcBatteryVoltage: false,
+      dcBatteryAvgVoltage: false,
     };
 
-    if (sensor.protection?.dcBatteryVoltage && rules.dcBatteryVoltage) {
-      this.logRule(rules.dcBatteryVoltage, sensor.voltage);
+    if (sensor.protection?.dcBatteryAvgVoltage && rules.dcBatteryAvgVoltage) {
+      this.logRule(rules.dcBatteryAvgVoltage, sensor.voltage);
 
-      result.dcBatteryVoltage = true;
+      result.dcBatteryAvgVoltage = true;
     }
 
     return result;

--- a/src/modules/protection-rules/strategies/protection.strategy.ts
+++ b/src/modules/protection-rules/strategies/protection.strategy.ts
@@ -11,17 +11,6 @@ export abstract class ProtectionStrategy {
 
   protected constructor(protected readonly logsService: LogsService) {}
 
-  protected checkRule(
-    rule: ProtectionRule | undefined,
-    value: number | undefined,
-  ): boolean {
-    if (!value || !rule?.min || !rule.max) {
-      return false;
-    }
-
-    return value < rule.min || value > rule.max;
-  }
-
   protected logRule(rule: ProtectionRule, value: number | undefined): void {
     return this.logsService.info({
       type: LogType.PROTECTION,

--- a/src/modules/relays/relays.module.ts
+++ b/src/modules/relays/relays.module.ts
@@ -2,12 +2,10 @@ import { Module } from '@nestjs/common';
 import { RelaysController } from './relays.controller';
 import { RelaysService } from './relays.service';
 import { EspApiModule } from '@api/modules/esp';
-import { LogsModule } from '../logs/logs.module';
 
 @Module({
-  imports: [EspApiModule, LogsModule],
+  imports: [EspApiModule],
   controllers: [RelaysController],
   providers: [RelaysService],
-  exports: [RelaysService],
 })
 export class RelaysModule {}

--- a/src/modules/relays/relays.service.ts
+++ b/src/modules/relays/relays.service.ts
@@ -1,14 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { EspRelayStatus, EspRelaysApiService } from '@api/modules/esp';
-import { LogType } from '../logs/enums';
-import { LogsService } from '../logs/logs.service';
 
 @Injectable()
 export class RelaysService {
-  constructor(
-    private readonly espRelaysApiService: EspRelaysApiService,
-    private readonly logsService: LogsService,
-  ) {}
+  constructor(private readonly espRelaysApiService: EspRelaysApiService) {}
 
   getRelayStatus(): Promise<EspRelayStatus> {
     return this.espRelaysApiService.getRelayStatus();
@@ -16,21 +11,5 @@ export class RelaysService {
 
   updatePowerRelay(status: boolean): Promise<EspRelayStatus> {
     return this.espRelaysApiService.updatePowerRelay(status);
-  }
-
-  switchPower(status: boolean, type: LogType): Promise<EspRelayStatus | void> {
-    return this.logsService.runWith(
-      () => this.espRelaysApiService.updatePowerRelay(status),
-      {
-        before: {
-          type,
-          message: `Changing power relay status to: ${status ? 'ON' : 'OFF'}`,
-        },
-        after: {
-          type,
-          message: `The error occurred during switching power relay status`,
-        },
-      },
-    );
   }
 }

--- a/src/modules/sensors/entities/sensor-item.entity.ts
+++ b/src/modules/sensors/entities/sensor-item.entity.ts
@@ -23,6 +23,10 @@ export class SensorItem {
 
   @Expose()
   @Column({ type: 'float', nullable: true })
+  avgVoltage?: number;
+
+  @Expose()
+  @Column({ type: 'float', nullable: true })
   current?: number;
 
   @Expose()
@@ -48,10 +52,6 @@ export class SensorItem {
   @Expose()
   @Column({ type: 'float', nullable: true })
   t2Energy?: number;
-
-  @Expose()
-  @Column({ type: 'float', nullable: true })
-  avgVoltage?: number;
 
   @Type(() => SensorProtection)
   @Expose()

--- a/src/modules/sensors/entities/sensor-protection.entity.ts
+++ b/src/modules/sensors/entities/sensor-protection.entity.ts
@@ -1,6 +1,9 @@
 import { Expose } from 'class-transformer';
+import { ProtectionRuleId } from '../../protection-rules/enums';
 
-export class SensorProtection {
+export class SensorProtection
+  implements Partial<Record<ProtectionRuleId, boolean>>
+{
   @Expose()
   acOutputFrequency?: boolean;
 
@@ -8,5 +11,8 @@ export class SensorProtection {
   acOutputVoltage?: boolean;
 
   @Expose()
-  dcBatteryVoltage?: boolean;
+  acOutputAvgVoltage?: boolean;
+
+  @Expose()
+  dcBatteryAvgVoltage?: boolean;
 }

--- a/src/modules/sensors/entities/sensor.entity.ts
+++ b/src/modules/sensors/entities/sensor.entity.ts
@@ -13,6 +13,14 @@ export class Sensor {
   createdAt!: Date | string;
 
   @Expose()
+  @Column()
+  power!: boolean;
+
+  @Expose()
+  @Column()
+  pTriggered!: boolean;
+
+  @Expose()
   @Type(() => SensorItem)
   @OneToMany(() => SensorItem, (item) => item.sensor, { cascade: true })
   sensors!: SensorItem[];

--- a/src/modules/sensors/sensors.service.ts
+++ b/src/modules/sensors/sensors.service.ts
@@ -56,7 +56,7 @@ export class SensorsService implements OnModuleInit {
       excludeExtraneousValues: true,
     });
 
-    if (!sensors.sensors.length) {
+    if (!sensors.sensors.length || this.appConfig.feature.useEspAvgVoltage) {
       return sensors;
     }
 
@@ -72,7 +72,9 @@ export class SensorsService implements OnModuleInit {
       const fallbackSensor: Sensor = {
         id: '',
         createdAt: new Date().toJSON(),
+        power: true,
         sensors: [],
+        pTriggered: false,
       };
 
       this.logger.error(err);

--- a/test/api/modules/esp/ws/sensors/mocks/sensors.service.mock.ts
+++ b/test/api/modules/esp/ws/sensors/mocks/sensors.service.mock.ts
@@ -5,7 +5,9 @@ import { EspSensorsData } from '@api/modules/esp';
 export class EspSensorsWsServiceMock implements ClassMock<EspSensorsWsService> {
   static readonly espSensorsDataMock: EspSensorsData = {
     createdAt: '2025-01-19T16:26:30.550Z',
+    power: false,
     sensors: [],
+    pTriggered: false,
   };
 
   handleMessage(data: EspSensorsData, raw: string): void {}

--- a/test/config/mocks/app.config.mock.ts
+++ b/test/config/mocks/app.config.mock.ts
@@ -10,6 +10,7 @@ export const AppConfigMock: AppConfigType = {
   },
   feature: {
     clearSensors: false,
+    useEspAvgVoltage: true,
     sensorCalcPeriod: 2,
   },
   logLevel: PinoLogLevel.TRACE,

--- a/test/modules/protection-rules/mocks/protection-rules.executor.mock.ts
+++ b/test/modules/protection-rules/mocks/protection-rules.executor.mock.ts
@@ -2,7 +2,7 @@ import { ClassMock } from '@common/types/test.types';
 import { ProtectionRulesExecutor } from '@modules/protection-rules/protection-rules.executor';
 import { ProtectionResultDto } from '@modules/protection-rules/dto';
 import { ProtectionRule } from '@modules/protection-rules/entities';
-import { SensorItem } from '@modules/sensors/entities';
+import { Sensor } from '@modules/sensors/entities';
 
 export class ProtectionRulesExecutorMock
   implements ClassMock<ProtectionRulesExecutor>
@@ -13,11 +13,11 @@ export class ProtectionRulesExecutorMock
       acOutputFrequency: false,
       acOutputVoltage: false,
       acOutputAvgVoltage: false,
-      dcBatteryVoltage: false,
+      dcBatteryAvgVoltage: false,
     },
   };
 
-  execute(sensors: SensorItem[], rules: ProtectionRule[]): ProtectionResultDto {
+  execute(sensors: Sensor, rules: ProtectionRule[]): ProtectionResultDto {
     return ProtectionRulesExecutorMock.protectionResultMock;
   }
 }

--- a/test/modules/relays/mocks/relays.service.mock.ts
+++ b/test/modules/relays/mocks/relays.service.mock.ts
@@ -2,7 +2,6 @@ import { ClassMock } from '@common/types/test.types';
 import { RelaysService } from '@modules/relays/relays.service';
 import { EspRelayStatus } from '@api/modules/esp';
 import { EspRelaysApiServiceMock } from '@api/modules/esp/collections/relays/mocks/relays.service.mock';
-import { LogType } from '@modules/logs/enums';
 
 export class RelaysServiceMock implements ClassMock<RelaysService> {
   async getRelayStatus(): Promise<EspRelayStatus> {
@@ -11,12 +10,5 @@ export class RelaysServiceMock implements ClassMock<RelaysService> {
 
   async updatePowerRelay(status: boolean): Promise<EspRelayStatus> {
     return EspRelaysApiServiceMock.relayStatusMock;
-  }
-
-  async switchPower(
-    status: boolean,
-    type: LogType,
-  ): Promise<EspRelayStatus | void> {
-    return;
   }
 }

--- a/test/modules/sensors/mocks/sensors.repository.mock.ts
+++ b/test/modules/sensors/mocks/sensors.repository.mock.ts
@@ -6,7 +6,9 @@ export class SensorsRepositoryMock implements ClassMock<SensorsRepository> {
   static readonly sensorMock: Sensor = {
     id: 'id',
     createdAt: new Date(),
+    power: true,
     sensors: [],
+    pTriggered: false,
   };
   static readonly sensorsMock: Sensor[] = [this.sensorMock];
 


### PR DESCRIPTION
## Description

- Migrate server rules evaluation to the ESP protection system
- Don't calculate average voltage on the server when the `useEspAvgVoltage` feature flag is true