### PR TITLE
SC-119: Asic scaling UAT testing

### DIFF
--- a/.changeset/hungry-tools-rule.md
+++ b/.changeset/hungry-tools-rule.md
@@ -3,3 +3,11 @@
 ---
 
 SC-119: Asic scaling UAT testing
+
+- Use async EventEmitter listeners
+- Handle and log unknown errors during Asic scaling
+- Update Asic scaling log messages
+- Prevent Asic from stopping when the status is not "mining" (also prevents stopping already stopped Asic)
+- Prevent Asic increment scaling when it is still starting
+- Prevent switching to the first Asic preset when the current preset is already the first
+- Change the debug log level to info for the runWith method

--- a/.changeset/hungry-tools-rule.md
+++ b/.changeset/hungry-tools-rule.md
@@ -1,0 +1,5 @@
+---
+'solar-control-be': minor
+---
+
+SC-119: Asic scaling UAT testing

--- a/src/modules/asics/asics-automation.service.ts
+++ b/src/modules/asics/asics-automation.service.ts
@@ -58,7 +58,7 @@ export class AsicsAutomationService implements OnApplicationBootstrap {
     );
   }
 
-  @OnEvent(CONTROL_RULE_SAVED_EVENT)
+  @OnEvent(CONTROL_RULE_SAVED_EVENT, { async: true })
   restartAsicScalingStrategies(rule: ControlRule): void {
     this.asicScalingStrategyExecutor.execute(rule);
   }

--- a/src/modules/asics/strategies/scaling/asics-scaling-down.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling-down.strategy.ts
@@ -69,9 +69,25 @@ export class AsicsScalingDownStrategy extends AsicsScalingStrategy {
     }
 
     if (activePresetIdx === 0) {
-      await this.asicsApiFacade.stop(ip, token);
+      const status = await this.asicsApiFacade.getStatus(ip);
 
-      return;
+      if (status.miner_state !== 'mining') {
+        return;
+      }
+
+      return this.logsService.runWith(
+        () => this.asicsApiFacade.stop(ip, token),
+        {
+          before: {
+            type: LogType.CONTROL,
+            message: `Stopping '${asic.hostname}' Asic on first preset`,
+          },
+          after: {
+            type: LogType.CONTROL,
+            message: `An error occurred during stopping '${asic.hostname}' Asic`,
+          },
+        },
+      );
     }
 
     const preset = tunedPresets[activePresetIdx - 1];
@@ -79,7 +95,7 @@ export class AsicsScalingDownStrategy extends AsicsScalingStrategy {
     await this.logsService.runWith(() => this.changePreset(ip, token, preset), {
       before: {
         type: LogType.CONTROL,
-        message: `Scaling down '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.name}' to '${preset.name}'`,
+        message: `Scaling down '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.pretty}' to '${preset.pretty}'`,
       },
       after: {
         type: LogType.CONTROL,

--- a/src/modules/asics/strategies/scaling/asics-scaling-down.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling-down.strategy.ts
@@ -19,9 +19,9 @@ export class AsicsScalingDownStrategy extends AsicsScalingStrategy {
     protected override readonly cache: Cache,
     protected override readonly asicsRepository: AsicsRepository,
     protected override readonly asicsApiFacade: AsicsApiFacade,
-    private readonly logsService: LogsService,
+    protected override readonly logsService: LogsService,
   ) {
-    super(cache, asicsRepository, asicsApiFacade);
+    super(cache, asicsRepository, asicsApiFacade, logsService);
   }
 
   shouldScale(sensor: EspSensorsData, rule: ControlRule): boolean {

--- a/src/modules/asics/strategies/scaling/asics-scaling-down.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling-down.strategy.ts
@@ -79,11 +79,11 @@ export class AsicsScalingDownStrategy extends AsicsScalingStrategy {
     await this.logsService.runWith(() => this.changePreset(ip, token, preset), {
       before: {
         type: LogType.CONTROL,
-        message: `Scaling down '${asic.hostname}' asic preset from '${perfSummary.current_preset?.name}' to '${preset.name}'`,
+        message: `Scaling down '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.name}' to '${preset.name}'`,
       },
       after: {
         type: LogType.CONTROL,
-        message: `Error occurred during scaling down '${asic.hostname}' Asic`,
+        message: `An error occurred during scaling down '${asic.hostname}' Asic`,
       },
     });
   }

--- a/src/modules/asics/strategies/scaling/asics-scaling-up.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling-up.strategy.ts
@@ -116,7 +116,7 @@ export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
       {
         before: {
           type: LogType.CONTROL,
-          message: `Switching '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.name}' to '${firstPreset.name}'`,
+          message: `Switching '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.pretty}' to '${firstPreset.pretty}'`,
         },
         after: {
           type: LogType.CONTROL,
@@ -147,7 +147,7 @@ export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
     await this.logsService.runWith(() => this.changePreset(ip, token, preset), {
       before: {
         type: LogType.CONTROL,
-        message: `Scaling up '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.name}' to '${preset.name}'`,
+        message: `Scaling up '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.pretty}' to '${preset.pretty}'`,
       },
       after: {
         type: LogType.CONTROL,

--- a/src/modules/asics/strategies/scaling/asics-scaling-up.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling-up.strategy.ts
@@ -89,11 +89,11 @@ export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
     await this.logsService.runWith(() => this.asicsApiFacade.start(ip, token), {
       before: {
         type: LogType.CONTROL,
-        message: `Starting '${asic.hostname}' Asic`,
+        message: `Starting the '${asic.hostname}' Asic`,
       },
       after: {
         type: LogType.CONTROL,
-        message: `Error occurred during starting '${asic.hostname}' Asic`,
+        message: `An error occurred during starting '${asic.hostname}' Asic`,
       },
     });
 
@@ -116,11 +116,11 @@ export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
       {
         before: {
           type: LogType.CONTROL,
-          message: `Switching '${asic.hostname}' asic preset from '${perfSummary.current_preset?.name}' to '${firstPreset.name}'`,
+          message: `Switching '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.name}' to '${firstPreset.name}'`,
         },
         after: {
           type: LogType.CONTROL,
-          message: `Error occurred during switching preset for '${asic.hostname}' Asic`,
+          message: `An error occurred during switching the '${asic.hostname}' Asic to the first preset`,
         },
       },
     );
@@ -147,11 +147,11 @@ export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
     await this.logsService.runWith(() => this.changePreset(ip, token, preset), {
       before: {
         type: LogType.CONTROL,
-        message: `Scaling up '${asic.hostname}' asic preset from '${perfSummary.current_preset?.name}' to '${preset.name}'`,
+        message: `Scaling up '${asic.hostname}' Asic preset from '${perfSummary.current_preset?.name}' to '${preset.name}'`,
       },
       after: {
         type: LogType.CONTROL,
-        message: `Error occurred during scaling up '${asic.hostname}' Asic`,
+        message: `An error occurred during scaling up '${asic.hostname}' Asic`,
       },
     });
   }

--- a/src/modules/asics/strategies/scaling/asics-scaling-up.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling-up.strategy.ts
@@ -16,14 +16,16 @@ import { LogType } from '../../../logs/enums';
 
 @Injectable()
 export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
+  private isStarting = false;
+
   constructor(
     @Inject(CACHE_MANAGER)
     protected override readonly cache: Cache,
     protected override readonly asicsRepository: AsicsRepository,
     protected override readonly asicsApiFacade: AsicsApiFacade,
-    private readonly logsService: LogsService,
+    protected override readonly logsService: LogsService,
   ) {
-    super(cache, asicsRepository, asicsApiFacade);
+    super(cache, asicsRepository, asicsApiFacade, logsService);
   }
 
   shouldScale(sensor: EspSensorsData, rule: ControlRule): boolean {
@@ -47,6 +49,10 @@ export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
 
     if (stoppedAsic) {
       return this.startAsicOnFirstPreset(stoppedAsic);
+    }
+
+    if (this.isStarting) {
+      return;
     }
 
     const { asic, perfSummary } = await this.findAsicWithPreset(
@@ -80,26 +86,44 @@ export class AsicsScalingUpStrategy extends AsicsScalingStrategy {
     const { ip, password } = asic;
     const token = await this.asicsApiFacade.login(ip, decrypt(password));
 
-    await this.asicsApiFacade.start(ip, token);
-    await delay(ASIC_START_IDLE_TIME);
-
-    const presets = await this.asicsApiFacade.getPresets(ip, token);
-    const preset = presets.find((preset) => preset.status === 'tuned');
-
-    if (!preset) {
-      return;
-    }
-
-    await this.logsService.runWith(() => this.changePreset(ip, token, preset), {
+    await this.logsService.runWith(() => this.asicsApiFacade.start(ip, token), {
       before: {
         type: LogType.CONTROL,
-        message: `Starting '${asic.hostname}' asic on first '${preset.name}' preset`,
+        message: `Starting '${asic.hostname}' Asic`,
       },
       after: {
         type: LogType.CONTROL,
         message: `Error occurred during starting '${asic.hostname}' Asic`,
       },
     });
+
+    this.isStarting = true;
+
+    await delay(ASIC_START_IDLE_TIME);
+
+    this.isStarting = false;
+
+    const presets = await this.asicsApiFacade.getPresets(ip, token);
+    const perfSummary = await this.asicsApiFacade.getPerfSummary(ip);
+    const firstPreset = presets.find((preset) => preset.status === 'tuned');
+
+    if (!firstPreset || firstPreset.name === perfSummary.current_preset?.name) {
+      return;
+    }
+
+    await this.logsService.runWith(
+      () => this.changePreset(ip, token, firstPreset),
+      {
+        before: {
+          type: LogType.CONTROL,
+          message: `Switching '${asic.hostname}' asic preset from '${perfSummary.current_preset?.name}' to '${firstPreset.name}'`,
+        },
+        after: {
+          type: LogType.CONTROL,
+          message: `Error occurred during switching preset for '${asic.hostname}' Asic`,
+        },
+      },
+    );
   }
 
   async incrementAsicPreset(

--- a/src/modules/asics/strategies/scaling/asics-scaling.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling.strategy.ts
@@ -14,6 +14,8 @@ import {
   AsicSetting,
 } from '@api/modules/asics';
 import { EspSensorsData, ESP_SENSORS_CACHE } from '@api/modules/esp';
+import { LogsService } from '../../../logs/logs.service';
+import { LogType } from '../../../logs/enums';
 
 export abstract class AsicsScalingStrategy {
   asics: Asic[] = [];
@@ -23,18 +25,26 @@ export abstract class AsicsScalingStrategy {
     protected readonly cache: Cache,
     protected readonly asicsRepository: AsicsRepository,
     protected readonly asicsApiFacade: AsicsApiFacade,
+    protected readonly logsService: LogsService,
   ) {}
 
   async run(rule: ControlRule): Promise<void> {
-    const sensor = await this.cache.get<EspSensorsData>(ESP_SENSORS_CACHE);
+    try {
+      const sensor = await this.cache.get<EspSensorsData>(ESP_SENSORS_CACHE);
 
-    if (!sensor?.sensors?.length || !this.shouldScale(sensor, rule)) {
-      return;
+      if (!sensor?.sensors?.length || !this.shouldScale(sensor, rule)) {
+        return;
+      }
+
+      this.asics = await this.asicsRepository.findWhere({ automated: true });
+
+      await this.scale();
+    } catch {
+      this.logsService.error({
+        type: LogType.CONTROL,
+        message: 'Unknown error occurred during scaling Asics',
+      });
     }
-
-    this.asics = await this.asicsRepository.findWhere({ automated: true });
-
-    await this.scale();
   }
 
   async findAsicWithPreset(

--- a/src/modules/asics/strategies/scaling/asics-scaling.strategy.ts
+++ b/src/modules/asics/strategies/scaling/asics-scaling.strategy.ts
@@ -42,7 +42,7 @@ export abstract class AsicsScalingStrategy {
     } catch {
       this.logsService.error({
         type: LogType.CONTROL,
-        message: 'Unknown error occurred during scaling Asics',
+        message: 'An unknown error occurred during scaling Asics',
       });
     }
   }

--- a/src/modules/automation/protection-rule/protection-rule.service.ts
+++ b/src/modules/automation/protection-rule/protection-rule.service.ts
@@ -35,7 +35,7 @@ export class ProtectionRuleService {
     private readonly cache: Cache,
   ) {}
 
-  @OnEvent(ESP_SENSORS_EVENT)
+  @OnEvent(ESP_SENSORS_EVENT, { async: true })
   async onSensorsEvent(sensor: EspSensorsData): Promise<void> {
     if (!sensor.sensors.length) {
       return;

--- a/src/modules/logs/logs.service.ts
+++ b/src/modules/logs/logs.service.ts
@@ -53,7 +53,7 @@ export class LogsService {
     options: RunWithLogOptions,
   ): Promise<T | void> {
     try {
-      this.debug(options.before);
+      this.info(options.before);
 
       return await callback();
     } catch {

--- a/src/modules/sensors/sensors.service.ts
+++ b/src/modules/sensors/sensors.service.ts
@@ -7,7 +7,7 @@ import { Observable, Subject, map } from 'rxjs';
 export class SensorsService {
   private readonly sensorsSse$ = new Subject<EspSensorsData>();
 
-  @OnEvent(ESP_SENSORS_EVENT)
+  @OnEvent(ESP_SENSORS_EVENT, { async: true })
   onSensorsEvent(data: EspSensorsData): void {
     this.sensorsSse$.next(data);
   }

--- a/test/modules/asics/strategies/scaling/asics-scaling-down.strategy.spec.ts
+++ b/test/modules/asics/strategies/scaling/asics-scaling-down.strategy.spec.ts
@@ -12,7 +12,11 @@ import { AsicsAuthApiServiceMock } from '@api/modules/asics/collections/auth/moc
 import { AsicsAutotuneApiServiceMock } from '@api/modules/asics/collections/autotune/mocks/autotune.service.mock';
 import { AsicsOtherApiServiceMock } from '@api/modules/asics/collections/other/mocks/other.service.mock';
 import { AsicsApiFacadeMock } from '@api/modules/asics/services/mocks/asics-api.facade.mock';
-import { AsicPerfSummary, AsicsApiFacade } from '@api/modules/asics';
+import {
+  AsicPerfSummary,
+  AsicsApiFacade,
+  AsicStatus,
+} from '@api/modules/asics';
 import { EspSensorsData, EspSensorId } from '@api/modules/esp';
 import { LogsService } from '@modules/logs/logs.service';
 import { LogsServiceMock } from '../../../logs/mocks/logs.service.mock';
@@ -187,6 +191,24 @@ describe('AsicsScalingDownStrategy', () => {
       await strategy.decrementAsicPreset(asicMock, perfSummaryMock);
 
       expect(stopSpy).toHaveBeenCalledWith(asicMock.ip, tokenMock);
+      expect(changePresetSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not stop asic when asic status is not mining', async () => {
+      const perfSummaryMock = {
+        current_preset: { name: asicTunedPreset1Mock.name },
+      } as AsicPerfSummary;
+      const statusMock = { miner_state: 'failure' } as AsicStatus;
+
+      const stopSpy = jest.spyOn(asicsApiFacade, 'stop');
+      const getStatusSpy = jest
+        .spyOn(asicsApiFacade, 'getStatus')
+        .mockResolvedValueOnce(statusMock);
+
+      await strategy.decrementAsicPreset(asicMock, perfSummaryMock);
+
+      expect(getStatusSpy).toHaveBeenCalledWith(asicMock.ip);
+      expect(stopSpy).not.toHaveBeenCalled();
       expect(changePresetSpy).not.toHaveBeenCalled();
     });
 

--- a/test/modules/asics/strategies/scaling/asics-scaling.strategy.spec.ts
+++ b/test/modules/asics/strategies/scaling/asics-scaling.strategy.spec.ts
@@ -48,6 +48,7 @@ describe('AsicsScaleStrategy', () => {
   let cache: Cache;
   let asicsRepository: AsicsRepository;
   let asicsApiFacade: AsicsApiFacade;
+  let logsService: LogsService;
 
   const { controlRuleMock } = ControlRuleRepositoryMock;
   const { tokenMock } = AsicsAuthApiServiceMock;
@@ -82,6 +83,7 @@ describe('AsicsScaleStrategy', () => {
     cache = module.get(CACHE_MANAGER);
     asicsRepository = module.get(AsicsRepository);
     asicsApiFacade = module.get(AsicsApiFacade);
+    logsService = module.get(LogsService);
   });
 
   it('should be defined', () => {
@@ -146,6 +148,19 @@ describe('AsicsScaleStrategy', () => {
       await strategy.run(controlRuleMock);
 
       expect(scaleSpy).toHaveBeenCalled();
+    });
+
+    it('should create log in case when error occurred', async () => {
+      const errorSpy = jest.spyOn(logsService, 'error');
+
+      jest.spyOn(strategy, 'scale').mockRejectedValueOnce(new Error('error'));
+
+      shouldScaleSpy.mockReturnValueOnce(true);
+      await cache.set(ESP_SENSORS_CACHE, sensorMock);
+
+      await strategy.run(controlRuleMock);
+
+      expect(errorSpy).toHaveBeenCalled();
     });
   });
 

--- a/test/modules/asics/strategies/scaling/asics-scaling.strategy.spec.ts
+++ b/test/modules/asics/strategies/scaling/asics-scaling.strategy.spec.ts
@@ -19,6 +19,8 @@ import {
   EspSensorId,
   ESP_SENSORS_CACHE,
 } from '@api/modules/esp';
+import { LogsService } from '@modules/logs/logs.service';
+import { LogsServiceMock } from '../../../logs/mocks/logs.service.mock';
 
 @Injectable()
 class AsicsScalingStrategyMock extends AsicsScalingStrategy {
@@ -27,8 +29,9 @@ class AsicsScalingStrategyMock extends AsicsScalingStrategy {
     protected override readonly cache: Cache,
     protected override readonly asicsRepository: AsicsRepository,
     protected override readonly asicsApiFacade: AsicsApiFacade,
+    protected override readonly logsService: LogsService,
   ) {
-    super(cache, asicsRepository, asicsApiFacade);
+    super(cache, asicsRepository, asicsApiFacade, logsService);
   }
 
   scale(): Promise<void> {
@@ -67,6 +70,10 @@ describe('AsicsScaleStrategy', () => {
         {
           provide: AsicsApiFacade,
           useClass: AsicsApiFacadeMock,
+        },
+        {
+          provide: LogsService,
+          useClass: LogsServiceMock,
         },
       ],
     }).compile();


### PR DESCRIPTION
## Description

- Use async EventEmitter listeners
- Handle and log unknown errors during Asic scaling
- Update Asic scaling log messages
- Prevent Asic from stopping when the status is not "mining" (also prevents stopping already stopped Asic)
- Prevent Asic increment scaling when it is still starting
- Prevent switching to the first Asic preset when the current preset is already the first
- Change the debug log level to info for the runWith method
